### PR TITLE
Added missing import

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -22,6 +22,7 @@ import types
 import re
 import operator
 import gzip
+import string
 import xml.dom.minidom 
 
 from math import sqrt, sin, cos, atan2, pi


### PR DESCRIPTION
Tested on Ubuntu 12.04, Python 2.7.3. Fixed error when trying to convert to PDF.